### PR TITLE
Use $XDG_DATA_HOME for user's files

### DIFF
--- a/src/wurm-launcher.sh
+++ b/src/wurm-launcher.sh
@@ -2,11 +2,11 @@
 
 pkgname=wurm-launcher
 
-if [[ ! -d "$HOME/.$pkgname" ]]; then
-    mkdir -p "$HOME/.$pkgname"
-    cp -rn /usr/share/"$pkgname"/WurmLauncher "$HOME/.$pkgname"
+if [[ ! -d "$XDG_DATA_HOME/.$pkgname" ]]; then
+    mkdir -p "$XDG_DATA_HOME/.$pkgname"
+    cp -rn /usr/share/"$pkgname"/WurmLauncher "$XDG_DATA_HOME/.$pkgname"
 fi
 
-cd "$HOME/.$pkgname"
+cd "$XDG_DATA_HOME/.$pkgname"
 ./WurmLauncher
 


### PR DESCRIPTION
Changed $HOME to $XDG_DATA_HOME (usually $HOME/.local/share).
It's done to comply with https://freedesktop.org/wiki/Software/xdg-user-dirs/ (or so I belive)
Perhaps it should be done with `${XDG_DATA_HOME:-$HOME/.local/share}` instead.